### PR TITLE
Added kicking of players from a running mission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.xml
 SimpleSlotBlock.iml
+.project

--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>Slot Blocker</name>
+	<name>Ciribob - Simple Slot Blocker</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Slot Blocker</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.dltk.core.scriptbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.ldt.nature</nature>
+	</natures>
+</projectDescription>

--- a/SimpleSlotBlockGameGUI.lua
+++ b/SimpleSlotBlockGameGUI.lua
@@ -138,6 +138,7 @@ function ssb.shouldAllowAircraftSlot(_playerID, _slotID) -- _slotID == Unit ID u
 
 end
 
+
 -- Logic to allow a player in a slot
 function ssb.allowAircraftSlot(_playerID, _slotID) -- _slotID == Unit ID unless its multi aircraft in which case slotID is unitId_seatID (added by FlightControl)
 
@@ -160,6 +161,7 @@ function ssb.allowAircraftSlot(_playerID, _slotID) -- _slotID == Unit ID unless 
   return _result
 
 end
+
 
 function ssb.checkClanSlot(_playerID, _unitName)
 
@@ -218,8 +220,6 @@ function ssb.setFlagValue(_flag, _number) -- Added by FlightControl
 end
 
 
-
-
 -- _slotID == Unit ID unless its multi aircraft in which case slotID is unitId_seatID
 function ssb.getUnitId(_slotID)
   local _unitId = tostring(_slotID)
@@ -232,6 +232,7 @@ function ssb.getUnitId(_slotID)
   return tonumber(_unitId)
 end
 
+
 function ssb.getGroupName(_slotID)
 
   local _name = DCS.getUnitProperty(_slotID, DCS.UNIT_GROUPNAME)
@@ -241,59 +242,12 @@ function ssb.getGroupName(_slotID)
 end
 
 
-ssb.onSimulationFrame = function() -- Added by FlightControl
-
-  -- For each slot, check the flags...
-
-  ssb.kickTimeNow = DCS.getModelTime()
-
-  -- Check every 5 seconds if a player needs to be kicked.
-  if ssb.kickPlayers and ssb.kickTimePrev + ssb.kickTimeInterval <= ssb.kickTimeNow then
-
-    ssb.kickTimePrev = ssb.kickTimeNow
-
-    if DCS.isServer() and DCS.isMultiplayer() then
-      if DCS.getModelTime() > 1 and  ssb.slotBlockEnabled() then  -- must check this to prevent a possible CTD by using a_do_script before the game is ready to use a_do_script. -- Source GRIMES :)
-
-        local Players = net.get_player_list()
-        for PlayerIDIndex, playerID in pairs( Players ) do
-
-          -- is player still in a valid slot
-          local _playerDetails = net.get_player_info( playerID )
-
-          if _playerDetails ~=nil and _playerDetails.side ~= 0 and _playerDetails.slot ~= "" and _playerDetails.slot ~= nil then
-
-            local _unitRole = DCS.getUnitType( _playerDetails.slot )
-            if _unitRole ~= nil and
-              ( _unitRole == "forward_observer" or
-              _unitRole == "instructor"or
-              _unitRole == "artillery_commander" or
-              _unitRole == "observer" )
-            then
-              return true
-            end
-
-            local _allow = ssb.shouldAllowAircraftSlot(playerID, _playerDetails.slot)
-
-            if not _allow then
-              ssb.rejectPlayer(playerID)
-            end
-          end
-        end
-      end
-    end
-  end
-end
-
-
-
 --- Reset the persistent variables when a new mission is loaded.
 ssb.onMissionLoadEnd = function()
 
   ssb.kickTimePrev = 0 -- Reset when a new mission has been loaded!
 
 end
-
 
 
 --- For each simulation frame, check if a player needs to be kicked.
@@ -345,8 +299,7 @@ ssb.onSimulationFrame = function()
 end
 
 
-
---DOC
+---DOC
 -- onGameEvent(eventName,arg1,arg2,arg3,arg4)
 --"friendly_fire", playerID, weaponName, victimPlayerID
 --"mission_end", winner, msg
@@ -428,6 +381,7 @@ ssb.onPlayerTryChangeSlot = function(playerID, side, slotID)
 
 end
 
+
 ssb.slotBlockEnabled = function()
 
   local _res = ssb.getFlagValue("SSB") --SSB disabled by Default
@@ -435,6 +389,7 @@ ssb.slotBlockEnabled = function()
   return _res == 100
 
 end
+
 
 ssb.rejectMessage = function(playerID)
   local _playerName = net.get_player_info(playerID, 'name')
@@ -457,6 +412,7 @@ ssb.rejectPlayer = function(playerID)
   ssb.rejectMessage(playerID)
   
 end
+
 
 ssb.trimStr = function(_str)
   return  string.format( "%s", _str:match( "^%s*(.-)%s*$" ) )

--- a/SimpleSlotBlockGameGUI.lua
+++ b/SimpleSlotBlockGameGUI.lua
@@ -287,6 +287,16 @@ end
 
 
 
+--- Reset the persistent variables when a new mission is loaded.
+ssb.onMissionLoadEnd = function()
+
+  ssb.kickTimePrev = 0 -- Reset when a new mission has been loaded!
+
+end
+
+
+
+--- For each simulation frame, check if a player needs to be kicked.
 ssb.onSimulationFrame = function()
 
   -- For each slot, check the flags...

--- a/SimpleSlotBlockGameGUI.lua
+++ b/SimpleSlotBlockGameGUI.lua
@@ -255,11 +255,8 @@ end
 --
 ssb.onGameEvent = function(eventName,playerID,arg2,arg3,arg4) -- This means if a slot is disabled while the player is flying, they'll be removed
 
-    net.log( "Event: "..eventName )
-
     if DCS.isServer() and DCS.isMultiplayer() then
         if DCS.getModelTime() > 1 and  ssb.slotBlockEnabled() then  -- must check this to prevent a possible CTD by using a_do_script before the game is ready to use a_do_script. -- Source GRIMES :)
-
 
             if eventName == "self_kill"
                     or eventName == "crash"

--- a/SimpleSlotBlockGameGUI.lua
+++ b/SimpleSlotBlockGameGUI.lua
@@ -1,7 +1,8 @@
 local ssb = {} -- DONT REMOVE!!!
+
 --[[
 
-   Simple Slot Block - V 1.0
+   Simple Slot Block - V 1.1
 
    Put this file in C:/Users/<YOUR USERNAME>/DCS/Scripts for 1.5 or C:/Users/<YOUR USERNAME>/DCS.openalpha/Scripts for 2.0
 
@@ -30,22 +31,31 @@ local ssb = {} -- DONT REMOVE!!!
 
    The flags will NOT interfere with mission flags
    
-   An addition has been done...
+   Additions:
    
-   You can now kick players out of their airplane or unit back to spectators during your running missions.
-   This by setting the flags ...
-   
-   A few things:
-   
-     - Kicking players is enabled by default, but you can disable the function by modifying ssb.KickPlayers.
-   
-       ssb.kickPlayers = false -- This will disable the players to be kicked. 
-       
-     - Slotblocker will check upon a defined time interval whether a player needs to be kicked.
+   * 2017-10-19 - FlightControl
      
-       ssb.kickTimeInterval = 5 -- Check every 5 seconds if a player needs to be kicked.
+     You can now kick players out of their airplane or unit back to spectators during your running missions.
+     This by setting user flags with the key the group name of the group seated by the player, to a value other than zero!
+     
+     => trigger.action.setUserFlag("HELI2",100) -- This will kick the group HELI2 when in the game.
+     
+       - Kicking players is enabled by default, but you can disable the function by modifying ssb.KickPlayers.
+         => ssb.kickPlayers = true -- (default) This will enable the players to be kicked. 
+         => ssb.kickPlayers = false -- This will disable the players to be kicked. 
+         
+       - Slotblocker will check upon a defined time interval whether a player needs to be kicked.
+         => ssb.kickTimeInterval = 1 -- (default) Check every 1 seconds if a player needs to be kicked.
+         => ssb.kickTimeInterval = 5 -- Check every 5 seconds if a player needs to be kicked.
+         
+       - By default, when a player gets kicked, its slot will be automatically unblocked.
+         But maybe the mission designer wants to mission to be in control which slots get unblocked.
+         => ssb.kickReset = true -- (default) The slot will be automatically reset to open, after kicking the player.
+         => ssb.kickReset = false -- The slot will NOT be automatically reset to open, after kicking the player.
 
- ]]
+       
+
+--]]
 
 ssb.showEnabledMessage = true -- if set to true, the player will be told that the slot is enabled when switching to it
 ssb.controlNonAircraftSlots = false -- if true, only unique DCS Player ids will be allowed for the Commander / GCI / Observer Slots
@@ -53,7 +63,8 @@ ssb.controlNonAircraftSlots = false -- if true, only unique DCS Player ids will 
 
 -- New addon version 1.1 -- kicking of players.
 ssb.kickPlayers = true -- Change to false if you want to disable to kick players.
-ssb.kickTimeInterval = 5 -- Change the amount of seconds if you want to shorten the interval time or make the interval time longer.
+ssb.kickTimeInterval = 1 -- Change the amount of seconds if you want to shorten the interval time or make the interval time longer.
+ssb.kickReset = true -- The slot will be automatically reset to open, after kicking the player.
 ssb.kickTimePrev = 0 -- leave this untouched!
 
 
@@ -76,11 +87,11 @@ ssb.enabledFlagValue = 0  -- what value to look for to enable a slot.
 -- The examples below can be turned on by removing the -- in front
 --
 ssb.prefixes = {
-     -- "-=104th=-",
-    -- "-=VSAAF=-",
-    -- "ciribob", -- you could also add in an actual player name instead
-    "some_clan_tag",
-    "-=AnotherClan=-",
+  -- "-=104th=-",
+  -- "-=VSAAF=-",
+  -- "ciribob", -- you could also add in an actual player name instead
+  "some_clan_tag",
+  "-=AnotherClan=-",
 }
 
 
@@ -90,8 +101,8 @@ ssb.prefixes = {
 -- This script will output them when a player changes slots so you can copy them out easily :)
 -- This will only take effect if: ssb.controlNonAircraftSlots = true
 ssb.commanderPlayerUCID = {
-    "292d911c1b6f631476795cb80fd93b1f",
-    "some_uniqe_player_ucid",
+  "292d911c1b6f631476795cb80fd93b1f",
+  "some_uniqe_player_ucid",
 }
 
 
@@ -103,131 +114,218 @@ ssb.version = "1.1"
 -- Logic for determining if player is allowed in a slot
 function ssb.shouldAllowAircraftSlot(_playerID, _slotID) -- _slotID == Unit ID unless its multi aircraft in which case slotID is unitId_seatID
 
-    local _groupName = ssb.getGroupName(_slotID)
+  local _groupName = ssb.getGroupName(_slotID)
 
-    if _groupName == nil or _groupName == "" then
-        net.log("SSB - Unable to get group name for slot ".._slotID)
-        return true
-    end
+  if _groupName == nil or _groupName == "" then
+    net.log("SSB - Unable to get group name for slot ".._slotID)
+    return true
+  end
 
-    _groupName = ssb.trimStr(_groupName)
+  _groupName = ssb.trimStr(_groupName)
 
-    if not ssb.checkClanSlot(_playerID, _groupName) then
-        return false
-    end
-
-    -- check flag value
-    local _flag = ssb.getFlagValue(_groupName)
-
-    if _flag == ssb.enabledFlagValue then
-        return true
-    end
-
+  if not ssb.checkClanSlot(_playerID, _groupName) then
     return false
+  end
+
+  -- check flag value
+  local _flag = ssb.getFlagValue(_groupName)
+
+  if _flag == ssb.enabledFlagValue then
+    return true
+  end
+
+  return false
+
+end
+
+-- Logic to allow a player in a slot
+function ssb.allowAircraftSlot(_playerID, _slotID) -- _slotID == Unit ID unless its multi aircraft in which case slotID is unitId_seatID (added by FlightControl)
+
+  local _groupName = ssb.getGroupName(_slotID)
+
+  if _groupName == nil or _groupName == "" then
+    net.log("SSB - Unable to get group name for slot ".._slotID)
+    return true
+  end
+
+  _groupName = ssb.trimStr(_groupName)
+
+  if not ssb.checkClanSlot(_playerID, _groupName) then
+    return false
+  end
+
+  -- check flag value
+  local _result = ssb.setFlagValue(_groupName, 0)
+
+  return _result
 
 end
 
 function ssb.checkClanSlot(_playerID, _unitName)
 
-    for _,_value in pairs(ssb.prefixes) do
+  for _,_value in pairs(ssb.prefixes) do
 
-        if string.find(_unitName, _value, 1, true) ~= nil then
+    if string.find(_unitName, _value, 1, true) ~= nil then
 
-            net.log("SSB - ".._unitName.." is clan slot for ".._value)
+      net.log("SSB - ".._unitName.." is clan slot for ".._value)
 
-            local _playerName = net.get_player_info(_playerID, 'name')
+      local _playerName = net.get_player_info(_playerID, 'name')
 
-            if _playerName ~= nil and string.find(_playerName, _value, 1, true) then
+      if _playerName ~= nil and string.find(_playerName, _value, 1, true) then
 
-                net.log("SSB - ".._playerName.." is clan member for ".._value.." for ".._unitName.." Allowing so far")
-                --passed clan test, carry on!
-                return true
-            end
+        net.log("SSB - ".._playerName.." is clan member for ".._value.." for ".._unitName.." Allowing so far")
+        --passed clan test, carry on!
+        return true
+      end
 
-            if _playerName ~= nil then
-                net.log("SSB - ".._playerName.." is NOT clan member for ".._value.." for ".._unitName.." Rejecting")
-            end
+      if _playerName ~= nil then
+        net.log("SSB - ".._playerName.." is NOT clan member for ".._value.." for ".._unitName.." Rejecting")
+      end
 
-            -- clan tag didnt match, quit!
-            return false
-        end
+      -- clan tag didnt match, quit!
+      return false
     end
+  end
 
-    return true
+  return true
 end
 
 
 function ssb.getFlagValue(_flag)
 
-    local _status,_error  = net.dostring_in('server', " return trigger.misc.getUserFlag(\"".._flag.."\"); ")
+  local _status,_error  = net.dostring_in('server', " return trigger.misc.getUserFlag(\"".._flag.."\"); ")
 
-    if not _status and _error then
-        net.log("SSB - error getting flag: ".._error)
-        return tonumber(ssb.enabledFlagValue)
-    else
+  if not _status and _error then
+    net.log("SSB - error getting flag: ".._error)
+    return tonumber(ssb.enabledFlagValue)
+  else
 
-        --disabled
-        return tonumber(_status)
-    end
+    --disabled
+    return tonumber(_status)
+  end
 end
+
+
+function ssb.setFlagValue(_flag, _number) -- Added by FlightControl
+
+  local _status,_error  = net.dostring_in('server', " return trigger.action.setUserFlag(\"".._flag.."\", " .. _number .. "); ")
+
+  if not _status and _error then
+    net.log("SSB - error setting flag: ".._error)
+    return false
+  end
+  return true
+end
+
+
+
 
 -- _slotID == Unit ID unless its multi aircraft in which case slotID is unitId_seatID
 function ssb.getUnitId(_slotID)
-    local _unitId = tostring(_slotID)
-    if string.find(tostring(_unitId),"_",1,true) then
-        --extract substring
-        _unitId = string.sub(_unitId,1,string.find(_unitId,"_",1,true))
-        net.log("Unit ID Substr ".._unitId)
-    end
+  local _unitId = tostring(_slotID)
+  if string.find(tostring(_unitId),"_",1,true) then
+    --extract substring
+    _unitId = string.sub(_unitId,1,string.find(_unitId,"_",1,true))
+    net.log("Unit ID Substr ".._unitId)
+  end
 
-    return tonumber(_unitId)
+  return tonumber(_unitId)
 end
 
 function ssb.getGroupName(_slotID)
 
-    local _name = DCS.getUnitProperty(_slotID, DCS.UNIT_GROUPNAME)
+  local _name = DCS.getUnitProperty(_slotID, DCS.UNIT_GROUPNAME)
 
-    return _name
+  return _name
 
 end
+
+
+ssb.onSimulationFrame = function() -- Added by FlightControl
+
+  -- For each slot, check the flags...
+
+  ssb.kickTimeNow = DCS.getModelTime()
+
+  -- Check every 5 seconds if a player needs to be kicked.
+  if ssb.kickPlayers and ssb.kickTimePrev + ssb.kickTimeInterval <= ssb.kickTimeNow then
+
+    ssb.kickTimePrev = ssb.kickTimeNow
+
+    if DCS.isServer() and DCS.isMultiplayer() then
+      if DCS.getModelTime() > 1 and  ssb.slotBlockEnabled() then  -- must check this to prevent a possible CTD by using a_do_script before the game is ready to use a_do_script. -- Source GRIMES :)
+
+        local Players = net.get_player_list()
+        for PlayerIDIndex, playerID in pairs( Players ) do
+
+          -- is player still in a valid slot
+          local _playerDetails = net.get_player_info( playerID )
+
+          if _playerDetails ~=nil and _playerDetails.side ~= 0 and _playerDetails.slot ~= "" and _playerDetails.slot ~= nil then
+
+            local _unitRole = DCS.getUnitType( _playerDetails.slot )
+            if _unitRole ~= nil and
+              ( _unitRole == "forward_observer" or
+              _unitRole == "instructor"or
+              _unitRole == "artillery_commander" or
+              _unitRole == "observer" )
+            then
+              return true
+            end
+
+            local _allow = ssb.shouldAllowAircraftSlot(playerID, _playerDetails.slot)
+
+            if not _allow then
+              ssb.rejectPlayer(playerID)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
 
 
 ssb.onSimulationFrame = function()
 
   -- For each slot, check the flags...
-  
+
   ssb.kickTimeNow = DCS.getModelTime()
-  
+
   -- Check every 5 seconds if a player needs to be kicked.
   if ssb.kickPlayers and ssb.kickTimePrev + ssb.kickTimeInterval <= ssb.kickTimeNow then
-    
+
     ssb.kickTimePrev = ssb.kickTimeNow
 
     if DCS.isServer() and DCS.isMultiplayer() then
       if DCS.getModelTime() > 1 and  ssb.slotBlockEnabled() then  -- must check this to prevent a possible CTD by using a_do_script before the game is ready to use a_do_script. -- Source GRIMES :)
-  
-        local Players = net.get_player_list()  
+
+        local Players = net.get_player_list()
         for PlayerIDIndex, playerID in pairs( Players ) do
-      
+
           -- is player still in a valid slot
           local _playerDetails = net.get_player_info( playerID )
-    
+
           if _playerDetails ~=nil and _playerDetails.side ~= 0 and _playerDetails.slot ~= "" and _playerDetails.slot ~= nil then
-    
+
             local _unitRole = DCS.getUnitType( _playerDetails.slot )
             if _unitRole ~= nil and
-                ( _unitRole == "forward_observer" or
-                  _unitRole == "instructor"or
-                  _unitRole == "artillery_commander" or
-                  _unitRole == "observer" )
+              ( _unitRole == "forward_observer" or
+              _unitRole == "instructor"or
+              _unitRole == "artillery_commander" or
+              _unitRole == "observer" )
             then
               return true
             end
-    
+
             local _allow = ssb.shouldAllowAircraftSlot(playerID, _playerDetails.slot)
-    
+
             if not _allow then
-                ssb.rejectPlayer(playerID)
+              ssb.rejectPlayer(playerID)
+              if ssb.kickReset then
+                ssb.allowAircraftSlot(playerID,_playerDetails.slot)
+              end    
             end
           end
         end
@@ -244,159 +342,114 @@ end
 --"mission_end", winner, msg
 --"kill", killerPlayerID, killerUnitType, killerSide, victimPlayerID, victimUnitType, victimSide, weaponName
 --"self_kill", playerID
---"change_slot", playerID, slotID, prevSide
---"connect", id, name
---"disconnect", ID_, name, playerSide
---"crash", playerID, unit_missionID
---"eject", playerID, unit_missionID
---"takeoff", playerID, unit_missionID, airdromeName
---"landing", playerID, unit_missionID, airdromeName
---"pilot_death", playerID, unit_missionID
---
-ssb.onGameEvent = function(eventName,playerID,arg2,arg3,arg4) -- This means if a slot is disabled while the player is flying, they'll be removed
-
-    if DCS.isServer() and DCS.isMultiplayer() then
-        if DCS.getModelTime() > 1 and  ssb.slotBlockEnabled() then  -- must check this to prevent a possible CTD by using a_do_script before the game is ready to use a_do_script. -- Source GRIMES :)
-
-            if eventName == "self_kill"
-                    or eventName == "crash"
-                    or eventName == "eject"
-                    or eventName ==  "pilot_death" then
-
-                -- is player still in a valid slot
-                local _playerDetails = net.get_player_info(playerID)
-
-                if _playerDetails ~=nil and _playerDetails.side ~= 0 and _playerDetails.slot ~= "" and _playerDetails.slot ~= nil then
-
-                    local _unitRole = DCS.getUnitType(_playerDetails.slot)
-                    if _unitRole ~= nil and
-                            (_unitRole == "forward_observer"
-                                    or _unitRole == "instructor"
-                                    or _unitRole == "artillery_commander"
-                                    or _unitRole == "observer")
-                    then
-                        return true
-                    end
-
-                    local _allow = ssb.shouldAllowSlot(playerID, _playerDetails.slot)
-
-                    if not _allow then
-                        ssb.rejectPlayer(playerID)
-                    end
-
-                end
-            end
-        end
-    end
-end
-
 ssb.onPlayerTryChangeSlot = function(playerID, side, slotID)
 
-    if  DCS.isServer() and DCS.isMultiplayer() then
-        if  (side ~=0 and  slotID ~='' and slotID ~= nil)  and  ssb.slotBlockEnabled() then
+  if  DCS.isServer() and DCS.isMultiplayer() then
+    if  (side ~=0 and  slotID ~='' and slotID ~= nil)  and  ssb.slotBlockEnabled() then
 
-            local _ucid = net.get_player_info(playerID, 'ucid')
-            local _playerName = net.get_player_info(playerID, 'name')
+      local _ucid = net.get_player_info(playerID, 'ucid')
+      local _playerName = net.get_player_info(playerID, 'name')
 
-            if _playerName == nil then
-                _playerName = ""
+      if _playerName == nil then
+        _playerName = ""
+      end
+
+      net.log("SSB - Player Selected slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid)
+
+      local _unitRole = DCS.getUnitType(slotID)
+
+      if _unitRole ~= nil and
+        (_unitRole == "forward_observer"
+        or _unitRole == "instructor"
+        or _unitRole == "artillery_commander"
+        or _unitRole == "observer")
+      then
+
+        net.log("SSB - Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
+
+        local _allow = false
+
+        if ssb.controlNonAircraftSlots and  ssb.slotBlockEnabled()  then
+
+          for _,_value in pairs(ssb.commanderPlayerUCID) do
+
+            if _value == _ucid then
+              _allow  = true
+              break
             end
+          end
 
-            net.log("SSB - Player Selected slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid)
+          if not _allow then
 
-            local _unitRole = DCS.getUnitType(slotID)
+            ssb.rejectMessage(playerID)
+            net.log("SSB - REJECTING Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
 
-            if _unitRole ~= nil and
-                    (_unitRole == "forward_observer"
-                            or _unitRole == "instructor"
-                            or _unitRole == "artillery_commander"
-                            or _unitRole == "observer")
-            then
-
-                net.log("SSB - Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
-
-                local _allow = false
-
-                if ssb.controlNonAircraftSlots and  ssb.slotBlockEnabled()  then
-
-                    for _,_value in pairs(ssb.commanderPlayerUCID) do
-
-                        if _value == _ucid then
-                            _allow  = true
-                            break
-                        end
-                    end
-
-                    if not _allow then
-
-                        ssb.rejectMessage(playerID)
-                        net.log("SSB - REJECTING Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
-
-                        return false
-                    end
-                end
-
-                net.log("SSB - ALLOWING Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
-
-                return true
-            else
-                local _allow = ssb.shouldAllowAircraftSlot(playerID,slotID)
-
-                if not _allow then
-                    net.log("SSB - REJECTING Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid)
-
-                    ssb.rejectMessage(playerID)
-
-                    return false
-                else
-                    if ssb.showEnabledMessage then
-                        --Disable chat message to user
-                        local _chatMessage = string.format("*** %s - Slot Allowed! ***",_playerName)
-                        net.send_chat_to(_chatMessage, playerID)
-                    end
-                end
-            end
-
-            net.log("SSB - ALLOWING Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid)
-
+            return false
+          end
         end
-    end
 
-    return true
+        net.log("SSB - ALLOWING Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
+
+        return true
+      else
+        local _allow = ssb.shouldAllowAircraftSlot(playerID,slotID)
+
+        if not _allow then
+          net.log("SSB - REJECTING Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid)
+
+          ssb.rejectMessage(playerID)
+
+          return false
+        else
+          if ssb.showEnabledMessage then
+            --Disable chat message to user
+            local _chatMessage = string.format("*** %s - Slot Allowed! ***",_playerName)
+            net.send_chat_to(_chatMessage, playerID)
+          end
+        end
+      end
+
+      net.log("SSB - ALLOWING Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid)
+
+    end
+  end
+
+  return true
 
 end
 
 ssb.slotBlockEnabled = function()
 
-    local _res = ssb.getFlagValue("SSB") --SSB disabled by Default
+  local _res = ssb.getFlagValue("SSB") --SSB disabled by Default
 
-    return _res == 100
+  return _res == 100
 
 end
 
 ssb.rejectMessage = function(playerID)
-    local _playerName = net.get_player_info(playerID, 'name')
+  local _playerName = net.get_player_info(playerID, 'name')
 
-    if _playerName ~= nil then
-        --Disable chat message to user
-        local _chatMessage = string.format("*** Sorry %s - Slot CURRENTLY DISABLED - Pick a different slot! ***",_playerName)
-        net.send_chat_to(_chatMessage, playerID)
-    end
+  if _playerName ~= nil then
+    --Disable chat message to user
+    local _chatMessage = string.format("*** Sorry %s - Slot CURRENTLY DISABLED - Pick a different slot! ***",_playerName)
+    net.send_chat_to(_chatMessage, playerID)
+  end
 
 end
 
 
 ssb.rejectPlayer = function(playerID)
-    net.log("SSB - REJECTING Slot - force spectators - "..playerID)
+  net.log("SSB - REJECTING Slot - force spectators - "..playerID)
 
-    -- put to spectators
-    net.force_player_slot(playerID, 0, '')
+  -- put to spectators
+  net.force_player_slot(playerID, 0, '')
 
-    ssb.rejectMessage(playerID)
+  ssb.rejectMessage(playerID)
+  
 end
 
 ssb.trimStr = function(_str)
-    return  string.format( "%s", _str:match( "^%s*(.-)%s*$" ) )
+  return  string.format( "%s", _str:match( "^%s*(.-)%s*$" ) )
 end
 
 DCS.setUserCallbacks(ssb)

--- a/SimpleSlotBlockGameGUI.lua
+++ b/SimpleSlotBlockGameGUI.lua
@@ -40,15 +40,21 @@ local ssb = {} -- DONT REMOVE!!!
      - Kicking players is enabled by default, but you can disable the function by modifying ssb.KickPlayers.
    
        ssb.kickPlayers = false -- This will disable the players to be kicked. 
-
-     - Once you have kicked a player, you may want to reset the flag to allow the player to enter again.
-       The slot will be blocked if the flag will remain keep a value other than 0.
+       
+     - Slotblocker will check upon a defined time interval whether a player needs to be kicked.
+     
+       ssb.kickTimeInterval = 5 -- Check every 5 seconds if a player needs to be kicked.
 
  ]]
 
-ssb.kickPlayers = true
 ssb.showEnabledMessage = true -- if set to true, the player will be told that the slot is enabled when switching to it
 ssb.controlNonAircraftSlots = false -- if true, only unique DCS Player ids will be allowed for the Commander / GCI / Observer Slots
+
+
+-- New addon version 1.1 -- kicking of players.
+ssb.kickPlayers = true -- Change to false if you want to disable to kick players.
+ssb.kickTimeInterval = 5 -- Change the amount of seconds if you want to shorten the interval time or make the interval time longer.
+ssb.kickTimePrev = 0 -- leave this untouched!
 
 
 -- If you set this to 0, all slots are ENABLED
@@ -92,7 +98,7 @@ ssb.commanderPlayerUCID = {
 
 ssb.version = "1.1"
 
-ssb.timePrev = 0
+
 
 -- Logic for determining if player is allowed in a slot
 function ssb.shouldAllowAircraftSlot(_playerID, _slotID) -- _slotID == Unit ID unless its multi aircraft in which case slotID is unitId_seatID
@@ -190,12 +196,12 @@ ssb.onSimulationFrame = function()
 
   -- For each slot, check the flags...
   
-  ssb.timeNow = DCS.getModelTime()
+  ssb.kickTimeNow = DCS.getModelTime()
   
   -- Check every 5 seconds if a player needs to be kicked.
-  if ssb.kickPlayers and ssb.timePrev + 5 <= ssb.timeNow then
+  if ssb.kickPlayers and ssb.kickTimePrev + ssb.kickTimeInterval <= ssb.kickTimeNow then
     
-    ssb.timePrev = ssb.timeNow
+    ssb.kickTimePrev = ssb.kickTimeNow
 
     if DCS.isServer() and DCS.isMultiplayer() then
       if DCS.getModelTime() > 1 and  ssb.slotBlockEnabled() then  -- must check this to prevent a possible CTD by using a_do_script before the game is ready to use a_do_script. -- Source GRIMES :)


### PR DESCRIPTION
Through the manipulation of the user flags, players can now also be kicked.
I also added a couple of additional variables that can be modified to disable / tweak the player kicking.

DCS has a bug in the multiplayer system. Unit:destroy() does not work in MP when a player seated from a client PC is destroyed on the server.

This development however, is better, as this allows also to block slots upon preference from the mission, not just kicking. So this has become a nice set of functions to use together with missions.

I hope this change will find its way in the community.

The MOOSE framework will make heavy use of this. For example in the AIRBASEPOLICE.
Speeding pilots on the runway will be kicked!

cheers,
Sven