### PR TITLE
Fix for multicrew prompt

### DIFF
--- a/SimpleSlotBlockGameGUI.lua
+++ b/SimpleSlotBlockGameGUI.lua
@@ -353,7 +353,7 @@ ssb.onPlayerTryChangeSlot = function(playerID, side, slotID)
 
         net.log("SSB - ALLOWING Player Selected Non Aircraft Slot - player: ".._playerName.." side:"..side.." slot: "..slotID.." ucid: ".._ucid.." type: ".._unitRole)
 
-        return true
+        return 
       else
         local _allow = ssb.shouldAllowAircraftSlot(playerID,slotID)
 
@@ -377,7 +377,7 @@ ssb.onPlayerTryChangeSlot = function(playerID, side, slotID)
     end
   end
 
-  return true
+  return 
 
 end
 


### PR DESCRIPTION
Removed return true value that interupted the multicrew check occurring from onPlayerTryChangeSlot. This should fix it so the prompt will appear. 

From API documentation:

For callbacks which are supposed to return a value, currently there are 3 of them:

    onPlayerTryConnect
    onPlayerTrySendChat
    onPlayerTryChangeSlot

returning a value means breaking the hook call chain. Returning nothing (or nil) means continuing the hook chain, which ends with the default allow-all handlers.